### PR TITLE
[CC-13] Bot API key

### DIFF
--- a/backend/app/api/v1/endpoints/assistant.py
+++ b/backend/app/api/v1/endpoints/assistant.py
@@ -8,8 +8,12 @@ from app.utils.assistant import (
     get_api_embedding,
     get_llm_api_response
 )
+from app.utils.vault import verify_api_key
 from app.crud.vectors import get_vector_neighbors
-from app.crud.bots import does_bot_exist
+from app.crud.bots import (
+    does_bot_exist,
+    get_vault_uuid
+)
 
 router = APIRouter()
 
@@ -17,10 +21,14 @@ router = APIRouter()
 @router.post("/assistant", response_model=AssistantResponse)
 def bot_contextual_response(bot_id: int, request_data: AssistantRequest):
     try:
+
         if not does_bot_exist(bot_id):
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Bot not found")
 
         passed_values = request_data.model_dump()
+
+        if not verify_api_key(passed_values["bot_api_key"], get_vault_uuid(bot_id)):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
 
         user_input_vector = SearchableVector(
             embedding=get_api_embedding(passed_values["user_input"])

--- a/backend/app/api/v1/endpoints/bots.py
+++ b/backend/app/api/v1/endpoints/bots.py
@@ -1,14 +1,20 @@
 from fastapi import APIRouter, HTTPException, Depends, status
-from app.schemas.bots import BotCreate, BotCreateResponse, BotUpdate, BotResponse
+from app.schemas.bots import (
+    BotCreate,
+    BotCreateResponse,
+    BotUpdate,
+    BotResponse,
+    BotUpdateKeyResponse
+)
 from app.crud import bots as crud
 from app.core.security import get_current_user, verify_bot_ownership
+from app.utils.vault import make_and_update_api_key
 
 router = APIRouter()
 
 
 @router.post("/", response_model=BotCreateResponse, status_code=status.HTTP_201_CREATED)
 def create_bot(bot_data: BotCreate, current_user: dict = Depends(get_current_user)):
-    # Need to add a checker for the bot data
     try:
         response = crud.create_bot(current_user["id"], bot_data)
         return {
@@ -66,6 +72,22 @@ def update_bot_by_id(
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error")
 
 
+@router.patch("/{bot_id}/api_key", response_model=BotUpdateKeyResponse)
+def update_bot_api_key(
+    bot_id: int,
+    _: dict = Depends(verify_bot_ownership),
+):
+    try:
+        vault_uuid = crud.get_vault_uuid(bot_id)
+        return {
+            "bot_id": bot_id,
+            "bot_api_key": make_and_update_api_key(vault_uuid)
+        }
+    except Exception as e:
+        print(f"Error updating bot API key: {e}")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error while deleting bot by id")
+
+
 @router.delete("/{bot_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_bot_by_id(
     bot_id: int,
@@ -76,5 +98,5 @@ def delete_bot_by_id(
         crud.delete_bot_by_id(current_user["id"], bot_id)
         return None
     except Exception as e:
-        print(f"Error updating bot: {e}")
+        print(f"Error deleting bot: {e}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error while deleting bot by id")

--- a/backend/app/api/v1/endpoints/bots.py
+++ b/backend/app/api/v1/endpoints/bots.py
@@ -1,16 +1,20 @@
 from fastapi import APIRouter, HTTPException, Depends, status
-from app.schemas.bots import BotCreate, BotUpdate, BotResponse
+from app.schemas.bots import BotCreate, BotCreateResponse, BotUpdate, BotResponse
 from app.crud import bots as crud
 from app.core.security import get_current_user, verify_bot_ownership
 
 router = APIRouter()
 
 
-@router.post("/", response_model=BotResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/", response_model=BotCreateResponse, status_code=status.HTTP_201_CREATED)
 def create_bot(bot_data: BotCreate, current_user: dict = Depends(get_current_user)):
     # Need to add a checker for the bot data
     try:
-        return crud.create_bot(current_user["id"], bot_data)
+        response = crud.create_bot(current_user["id"], bot_data)
+        return {
+            "bot_info": response[0],
+            "bot_api_key": response[1]
+        }
     except Exception as e:
         print(f"Error creating bot: {e}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error while creating bot")

--- a/backend/app/crud/bots.py
+++ b/backend/app/crud/bots.py
@@ -1,8 +1,6 @@
 from app.schemas.bots import BotCreate, BotUpdate
 from app.core.supabase import supabase_admin
-import hashlib
-import base64
-import os
+from app.utils.vault import make_and_store_api_key
 
 
 def create_bot(user_id: str, bot_data: BotCreate):
@@ -67,23 +65,12 @@ def does_bot_exist(bot_id: int) -> bool:
     return True if response.data else False
 
 
-# used to generate API key and its hash for the bots
-def generate_api_key(length: int) -> tuple[str, str]:
-    raw_bytes = os.urandom(length)
-    raw_key = f"bot_response_{base64.urlsafe_b64encode(raw_bytes).decode().rstrip('=')}"
-    hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
-    return raw_key, hashed_key
-
-
-# returns the API key to present to the user and the UUID of the secret in the vault
-def make_and_store_api_key() -> tuple[str, str]:
-    api_key_and_hash = generate_api_key(32)
-    response = supabase_admin.rpc(
-        "insert_secret",
-        {
-            "secret": api_key_and_hash[1],
-        }
-    ).execute()
-    vault_uuid = response.data
-
-    return api_key_and_hash[0], vault_uuid
+# used for checking the bots API key against passed API key
+def get_vault_uuid(bot_id: int) -> str:
+    response = (
+        supabase_admin.table("bots")
+        .select("vault_uuid")
+        .eq("bot_id", bot_id)
+        .execute()
+    )
+    return response.data[0]["vault_uuid"]

--- a/backend/app/crud/bots.py
+++ b/backend/app/crud/bots.py
@@ -1,13 +1,19 @@
 from app.schemas.bots import BotCreate, BotUpdate
 from app.core.supabase import supabase_admin
+import hashlib
+import base64
+import os
 
 
 def create_bot(user_id: str, bot_data: BotCreate):
     bot_dict = bot_data.model_dump()
     bot_dict["user_id"] = user_id
 
-    response = supabase_admin.table("bots").insert(bot_dict).execute()
-    return response.data[0]
+    method_response = make_and_store_api_key()
+    bot_dict["vault_uuid"] = method_response[1]
+
+    db_response = supabase_admin.table("bots").insert(bot_dict).execute()
+    return db_response.data[0], method_response[0]
 
 
 def get_all_bots(user_id: str):
@@ -59,3 +65,25 @@ def does_bot_exist(bot_id: int) -> bool:
         .execute()
     )
     return True if response.data else False
+
+
+# used to generate API key and its hash for the bots
+def generate_api_key(length: int) -> tuple[str, str]:
+    raw_bytes = os.urandom(length)
+    raw_key = f"bot_response_{base64.urlsafe_b64encode(raw_bytes).decode().rstrip('=')}"
+    hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
+    return raw_key, hashed_key
+
+
+# returns the API key to present to the user and the UUID of the secret in the vault
+def make_and_store_api_key() -> tuple[str, str]:
+    api_key_and_hash = generate_api_key(32)
+    response = supabase_admin.rpc(
+        "insert_secret",
+        {
+            "secret": api_key_and_hash[1],
+        }
+    ).execute()
+    vault_uuid = response.data
+
+    return api_key_and_hash[0], vault_uuid

--- a/backend/app/schemas/assistant.py
+++ b/backend/app/schemas/assistant.py
@@ -8,6 +8,7 @@ class ChatMessage(BaseModel):
 
 
 class AssistantRequest(BaseModel):
+    bot_api_key: str
     chat_history: List[ChatMessage]
     user_input: str
 

--- a/backend/app/schemas/bots.py
+++ b/backend/app/schemas/bots.py
@@ -28,3 +28,8 @@ class BotResponse(BotBase):
 
     class Config:
         from_attributes = True  # Allows Pydantic to read data from database models
+
+
+class BotCreateResponse(BaseModel):
+    bot_info: BotResponse
+    bot_api_key: str

--- a/backend/app/schemas/bots.py
+++ b/backend/app/schemas/bots.py
@@ -33,3 +33,8 @@ class BotResponse(BotBase):
 class BotCreateResponse(BaseModel):
     bot_info: BotResponse
     bot_api_key: str
+
+
+class BotUpdateKeyResponse(BaseModel):
+    bot_id: int
+    bot_api_key: str

--- a/backend/app/utils/vault.py
+++ b/backend/app/utils/vault.py
@@ -1,0 +1,44 @@
+from app.core.supabase import supabase_admin
+import hashlib
+import base64
+import hmac
+import os
+
+
+# used to generate API key and its hash for the bots
+def generate_api_key(length: int) -> tuple[str, str]:
+    raw_bytes = os.urandom(length)
+    raw_key = f"bot_response_{base64.urlsafe_b64encode(raw_bytes).decode().rstrip('=')}"
+    hashed_key = hashlib.sha256(raw_key.encode()).hexdigest()
+    return raw_key, hashed_key
+
+
+# returns the API key to present to the user and the UUID of the secret in the vault
+def make_and_store_api_key() -> tuple[str, str]:
+    api_key_and_hash = generate_api_key(32)
+    response = supabase_admin.rpc(
+        "insert_secret",
+        {
+            "secret": api_key_and_hash[1],
+        }
+    ).execute()
+    vault_uuid = response.data
+
+    return api_key_and_hash[0], vault_uuid
+
+
+def get_secret(vault_uuid: str) -> str:
+    response = supabase_admin.rpc(
+        "get_secret",
+        {
+            "secret_id": vault_uuid,
+        }
+    ).execute()
+    return response.data
+
+
+def verify_api_key(incoming_key: str, vault_uuid: str) -> bool:
+    stored_hash = get_secret(vault_uuid)
+    incoming_hash = hashlib.sha256(incoming_key.encode()).hexdigest()
+    return hmac.compare_digest(incoming_hash, stored_hash)
+    # hmac prevents timing attack, always same amount of time each comparison

--- a/backend/app/utils/vault.py
+++ b/backend/app/utils/vault.py
@@ -27,6 +27,18 @@ def make_and_store_api_key() -> tuple[str, str]:
     return api_key_and_hash[0], vault_uuid
 
 
+def make_and_update_api_key(vault_uuid: str) -> str:
+    api_key_and_hash = generate_api_key(32)
+    response = supabase_admin.rpc(
+        "update_secret",
+        {
+            "secret_id": vault_uuid,
+            "secret": api_key_and_hash[1],
+        }
+    ).execute()
+    return api_key_and_hash[0]
+
+
 def get_secret(vault_uuid: str) -> str:
     response = supabase_admin.rpc(
         "get_secret",

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -295,7 +295,7 @@ def sample_feedback_data():
 @pytest.fixture
 def sample_assistant_request():
     """
-    Provides sample assistant request for llm response.
+    Provides sample assistant request for llm response, need to add ["bot_api_key"]
     """
     return {
         "chat_history": [
@@ -318,18 +318,18 @@ def sample_assistant_request():
 @pytest.fixture
 def created_bot(client, auth_headers, sample_bot_data):
     """
-    Creates a test bot and return its ID. Cleans up after test.
+    Creates a test bot and return its values.
 
     Usage:
         def test_something(client, auth_headers, test_bot_id):
             response = client.get(f"/bots/{test_bot_id}")
     """
     response = client.post(f"{API_PREFIX}/bots", json=sample_bot_data, headers=auth_headers)
-    bot = response.json()["bot_info"]
+    bot = response.json()
 
     yield bot
 
-    client.delete(f"{API_PREFIX}/bots/{bot["bot_id"]}", headers=auth_headers)
+    client.delete(f"{API_PREFIX}/bots/{bot["bot_info"]["bot_id"]}", headers=auth_headers)
 
 
 @pytest.fixture
@@ -350,7 +350,7 @@ def created_document(client, auth_headers, created_bot, sample_txt_file):
     }
 
     response = client.post(
-        f"{API_PREFIX}/bots/{created_bot["bot_id"]}/documents",
+        f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/documents",
         files=files,
         data=data,
         headers=auth_headers
@@ -361,7 +361,7 @@ def created_document(client, auth_headers, created_bot, sample_txt_file):
 
     try:
         client.delete(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/documents/{document['doc_id']}",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/documents/{document['doc_id']}",
             headers=auth_headers
         )
     except Exception:

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -325,7 +325,7 @@ def created_bot(client, auth_headers, sample_bot_data):
             response = client.get(f"/bots/{test_bot_id}")
     """
     response = client.post(f"{API_PREFIX}/bots", json=sample_bot_data, headers=auth_headers)
-    bot = response.json()
+    bot = response.json()["bot_info"]
 
     yield bot
 

--- a/backend/tests/unit/test_assistant.py
+++ b/backend/tests/unit/test_assistant.py
@@ -6,8 +6,10 @@ class TestBotContextualResponse:
     def test_bot_contextual_response_returns_200_and_response(
         self, client, created_bot, sample_assistant_request,
     ):
+        sample_assistant_request["bot_api_key"] = created_bot["bot_api_key"]
+
         response = client.post(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/assistant",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/assistant",
             json=sample_assistant_request
         )
 
@@ -16,9 +18,23 @@ class TestBotContextualResponse:
     def test_bot_contextual_response_for_nonexistent_bot_returns_404(
         self, client, sample_assistant_request,
     ):
+        sample_assistant_request["bot_api_key"] = ""
+
         response = client.post(
             f"{API_PREFIX}/bots/{NONEXISTENT_BOT_ID}/assistant",
             json=sample_assistant_request
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_bot_contextual_response_for_nonexistent_api_key_returns_401(
+        self, client, created_bot, sample_assistant_request,
+    ):
+        sample_assistant_request["bot_api_key"] = ""
+
+        response = client.post(
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/assistant",
+            json=sample_assistant_request
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/backend/tests/unit/test_bots.py
+++ b/backend/tests/unit/test_bots.py
@@ -12,13 +12,18 @@ class TestCreateBot:
 
         assert response.status_code == status.HTTP_201_CREATED
         json_data = response.json()
-        assert json_data["bot_name"] == "Test Bot"
-        assert json_data["bot_desc"] == "A bot for testing"
-        assert json_data["avatar"] == "base"
-        assert json_data["color"] == "tan"
-        assert json_data["storage"] == 0
-        assert json_data["uses"] == 0
-        assert "bot_id" in json_data
+        assert json_data["bot_info"]["bot_name"] == "Test Bot"
+        assert json_data["bot_info"]["bot_desc"] == "A bot for testing"
+        assert json_data["bot_info"]["avatar"] == "base"
+        assert json_data["bot_info"]["color"] == "tan"
+        assert json_data["bot_info"]["storage"] == 0
+        assert json_data["bot_info"]["uses"] == 0
+        assert "bot_id" in json_data["bot_info"]
+
+        assert "bot_api_key" in json_data
+        assert json_data["bot_api_key"].startswith("bot_response_")
+        assert len(json_data["bot_api_key"]) > 20
+        print(json_data["bot_api_key"])
 
     def test_create_bot_without_auth_returns_401(self, client, invalid_auth_headers, sample_bot_data):
         response = client.post(
@@ -172,7 +177,7 @@ class TestUpdateBotByID:
 class TestDeleteBotByID:
     def test_delete_bot_by_id_returns_204(self, client, auth_headers, sample_bot_data):
         set_up_response = client.post(f"{API_PREFIX}/bots", json=sample_bot_data, headers=auth_headers)
-        bot = set_up_response.json()
+        bot = set_up_response.json()["bot_info"]
 
         response = client.delete(
             f"{API_PREFIX}/bots/{bot["bot_id"]}",
@@ -193,7 +198,7 @@ class TestDeleteBotByID:
             self, client, auth_headers, invalid_auth_headers, sample_bot_data
     ):
         set_up_response = client.post(f"{API_PREFIX}/bots", json=sample_bot_data, headers=auth_headers)
-        bot = set_up_response.json()
+        bot = set_up_response.json()["bot_info"]
 
         response = client.delete(
             f"{API_PREFIX}/bots/{bot["bot_id"]}",

--- a/backend/tests/unit/test_bots.py
+++ b/backend/tests/unit/test_bots.py
@@ -174,6 +174,33 @@ class TestUpdateBotByID:
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
+class TestUpdateBotAPIKey:
+    def test_update_bot_api_key_returns_200_and_key(self, client, auth_headers, created_bot):
+        response = client.patch(
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/api_key",
+            headers=auth_headers
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert isinstance(response.json()["bot_api_key"], str)
+
+    def test_update_bot_api_key_for_nonexistent_bot_returns_404(self, client, auth_headers):
+        response = client.patch(
+            f"{API_PREFIX}/bots/{NONEXISTENT_BOT_ID}/api_key",
+            headers=auth_headers
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_update_bot_api_key_without_auth_returns_401(self, client, invalid_auth_headers, created_bot):
+        response = client.patch(
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/api_key",
+            headers=invalid_auth_headers
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
 class TestDeleteBotByID:
     def test_delete_bot_by_id_returns_204(self, client, auth_headers, sample_bot_data):
         set_up_response = client.post(f"{API_PREFIX}/bots", json=sample_bot_data, headers=auth_headers)

--- a/backend/tests/unit/test_bots.py
+++ b/backend/tests/unit/test_bots.py
@@ -61,7 +61,7 @@ class TestGetAllBots:
 class TestGetBotById:
     def test_get_bot_by_id_returns_200_and_bot(self, client, auth_headers, created_bot):
         response = client.get(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}",
             headers=auth_headers
         )
 
@@ -85,7 +85,7 @@ class TestGetBotById:
 
     def test_get_bot_by_id_without_auth_returns_401(self, client, invalid_auth_headers, created_bot):
         response = client.get(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}",
             headers=invalid_auth_headers
         )
 
@@ -97,7 +97,7 @@ class TestUpdateBotByID:
         update_data = {"bot_name": "Updated Bot"}
 
         response = client.patch(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}",
             json=update_data,
             headers=auth_headers
         )
@@ -124,7 +124,7 @@ class TestUpdateBotByID:
         }
 
         response = client.patch(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}",
             json=update_data,
             headers=auth_headers
         )
@@ -144,7 +144,7 @@ class TestUpdateBotByID:
         update_data = {}
 
         response = client.patch(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}",
             json=update_data,
             headers=auth_headers
         )
@@ -166,7 +166,7 @@ class TestUpdateBotByID:
         update_data = {"bot_name": "Updated Bot"}
 
         response = client.patch(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}",
             json=update_data,
             headers=invalid_auth_headers
         )

--- a/backend/tests/unit/test_documents.py
+++ b/backend/tests/unit/test_documents.py
@@ -19,7 +19,7 @@ class TestCreateDocument:
         }
 
         response = client.post(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/documents",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/documents",
             files=files,
             data=data,
             headers=auth_headers
@@ -32,7 +32,7 @@ class TestCreateDocument:
         assert "doc_id" in json_data
 
         client.delete(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/documents/{json_data['doc_id']}",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/documents/{json_data['doc_id']}",
             headers=auth_headers
         )
 
@@ -47,7 +47,7 @@ class TestCreateDocument:
         }
 
         response = client.post(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/documents",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/documents",
             files=files,
             data=data,
             headers=auth_headers
@@ -66,7 +66,7 @@ class TestCreateDocument:
         }
 
         response = client.post(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/documents",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/documents",
             files=files,
             data=data,
             headers=auth_headers
@@ -84,7 +84,7 @@ class TestCreateDocument:
         }
 
         first_response = client.post(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/documents",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/documents",
             files=files,
             data=data,
             headers=auth_headers
@@ -94,7 +94,7 @@ class TestCreateDocument:
 
         sample_txt_file.seek(0)  # Reset file pointer
         second_response = client.post(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/documents",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/documents",
             files=files,
             data=data,
             headers=auth_headers
@@ -103,7 +103,7 @@ class TestCreateDocument:
         assert second_response.status_code == status.HTTP_409_CONFLICT
         assert "Document already exists" in second_response.json()["detail"]
 
-        client.delete(f"{API_PREFIX}/bots/{created_bot["bot_id"]}/documents/{doc_id}", headers=auth_headers)
+        client.delete(f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/documents/{doc_id}", headers=auth_headers)
 
     def test_create_doc_without_auth_returns_401(self, client, invalid_auth_headers, created_bot, sample_txt_file):
         files = {"file": ("test.txt", sample_txt_file, "text/plain")}
@@ -114,7 +114,7 @@ class TestCreateDocument:
         }
 
         response = client.post(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/documents",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/documents",
             files=files,
             data=data,
             headers=invalid_auth_headers
@@ -145,7 +145,7 @@ class TestGetAllDocuments:
 
     def test_get_documents_returns_200_and_document_list(self, client, auth_headers, created_bot):
         response = client.get(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/documents",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/documents",
             headers=auth_headers
         )
 
@@ -154,7 +154,7 @@ class TestGetAllDocuments:
 
     def test_get_documents_without_auth_returns_401(self, client, invalid_auth_headers, created_bot):
         response = client.get(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/documents",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/documents",
             headers=invalid_auth_headers
         )
 
@@ -214,7 +214,7 @@ class TestGetDocumentById:
 
     def test_get_document_by_id_for_nonexistent_doc_returns_404(self, client, auth_headers, created_bot):
         response = client.get(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/documents/{NONEXISTENT_DOC_ID}",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/documents/{NONEXISTENT_DOC_ID}",
             headers=auth_headers
         )
 
@@ -261,7 +261,7 @@ class TestDownloadDocumentById:
 
     def test_download_documents_by_id_for_nonexistent_doc_returns_404(self, client, auth_headers, created_bot):
         response = client.get(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/documents/{NONEXISTENT_DOC_ID}/download",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/documents/{NONEXISTENT_DOC_ID}/download",
             headers=auth_headers
         )
 
@@ -278,7 +278,7 @@ class TestDeleteDocumentById:
             "doc_size": TEST_TXT_SIZE
         }
         create_response = client.post(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/documents",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/documents",
             files=files,
             data=data,
             headers=auth_headers
@@ -286,7 +286,7 @@ class TestDeleteDocumentById:
         doc_id = create_response.json()["doc_id"]
 
         response = client.delete(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/documents/{doc_id}",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/documents/{doc_id}",
             headers=auth_headers
         )
 
@@ -306,7 +306,7 @@ class TestDeleteDocumentById:
 
     def test_delete_document_by_id_for_nonexistent_doc_returns_404(self, client, auth_headers, created_bot):
         response = client.delete(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/documents/{NONEXISTENT_DOC_ID}",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/documents/{NONEXISTENT_DOC_ID}",
             headers=auth_headers
         )
 

--- a/backend/tests/unit/test_feedback.py
+++ b/backend/tests/unit/test_feedback.py
@@ -10,7 +10,7 @@ from fastapi import status
 class TestCreateFeedback:
     def test_create_feedback_returns_201(self, client, auth_headers, created_bot, sample_feedback_data):
         response = client.post(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/feedback",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/feedback",
             json=sample_feedback_data,
             headers=auth_headers
         )
@@ -30,7 +30,7 @@ class TestCreateFeedback:
             self, client, invalid_auth_headers, created_bot, sample_feedback_data
     ):
         response = client.post(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/feedback",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/feedback",
             json=sample_feedback_data,
             headers=invalid_auth_headers
         )
@@ -41,7 +41,7 @@ class TestCreateFeedback:
 class TestGetAllFeedback:
     def test_get_all_feedback_returns_200_and_list(self, client, auth_headers, created_bot):
         response = client.get(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/feedback",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/feedback",
             headers=auth_headers
         )
 
@@ -58,7 +58,7 @@ class TestGetAllFeedback:
 
     def test_get_all_feedback_without_auth_returns_401(self, client, invalid_auth_headers, created_bot):
         response = client.get(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/feedback",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/feedback",
             headers=invalid_auth_headers
         )
 
@@ -68,14 +68,14 @@ class TestGetAllFeedback:
 class TestGetFeedbackById:
     def test_get_feedback_by_id_returns_200_and_object(self, client, auth_headers, created_bot, sample_feedback_data):
         set_up_response = client.post(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/feedback",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/feedback",
             json=sample_feedback_data,
             headers=auth_headers
         )
         feedback = set_up_response.json()
 
         response = client.get(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/feedback/{feedback["fb_id"]}",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/feedback/{feedback["fb_id"]}",
             headers=auth_headers
         )
 
@@ -89,7 +89,7 @@ class TestGetFeedbackById:
 
     def test_get_feedback_by_id_for_nonexistent_feedback_returns_404(self, client, auth_headers, created_bot):
         response = client.get(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/feedback{NONEXISTENT_FB_ID}",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/feedback{NONEXISTENT_FB_ID}",
             headers=auth_headers
         )
 
@@ -107,14 +107,14 @@ class TestGetFeedbackById:
             self, client, auth_headers, invalid_auth_headers, created_bot, sample_feedback_data
     ):
         set_up_response = client.post(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/feedback",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/feedback",
             json=sample_feedback_data,
             headers=auth_headers
         )
         feedback = set_up_response.json()
 
         response = client.get(
-            f"{API_PREFIX}/bots/{created_bot["bot_id"]}/feedback/{feedback["fb_id"]}",
+            f"{API_PREFIX}/bots/{created_bot["bot_info"]["bot_id"]}/feedback/{feedback["fb_id"]}",
             headers=invalid_auth_headers
         )
 

--- a/supabase/migrations/20251226061557_all_migrations.sql
+++ b/supabase/migrations/20251226061557_all_migrations.sql
@@ -21,7 +21,8 @@ CREATE TABLE bots (
     avatar TEXT,
     color TEXT,
     storage INT, -- KB used in document storage
-    uses INT -- perhaps switch to bigint if thought needed
+    uses INT, -- perhaps switch to bigint if thought needed
+    vault_uuid UUID -- reference for API key in vaults
 );
 
 -- Table storing the documents relating to each bot.
@@ -71,6 +72,7 @@ create extension vector
 with
     schema extensions;
 
+-- Table storing the vectorized document embeddings
 CREATE TABLE vectors (
     vec_id BIGSERIAL PRIMARY KEY,
     doc_id BIGINT REFERENCES documents(doc_id) ON DELETE CASCADE,
@@ -79,4 +81,9 @@ CREATE TABLE vectors (
     embedding extensions.vector(768) NOT NULL
 );
 
--- Table storing the vectorized documents
+
+-- SECRETS
+
+CREATE EXTENSION IF NOT EXISTS supabase_vault CASCADE;
+
+

--- a/supabase/migrations/20251226061640_functions.sql
+++ b/supabase/migrations/20251226061640_functions.sql
@@ -87,8 +87,25 @@ RETURNS UUID
 LANGUAGE plpgsql
 SECURITY DEFINER
 AS $$
+DECLARE
+  new_uuid UUID;
 BEGIN
-  RETURN vault.create_secret(secret);
+  SELECT vault.create_secret(secret) INTO new_uuid;
+  RETURN new_uuid;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.update_secret(secret_id UUID, secret TEXT)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  PERFORM vault.update_secret(
+    secret_id := secret_id,
+    new_secret := secret
+  );
+  RETURN;
 END;
 $$;
 

--- a/supabase/migrations/20251226061640_functions.sql
+++ b/supabase/migrations/20251226061640_functions.sql
@@ -56,14 +56,12 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
-
 -- Drop and then Create the trigger to ensure idempotency (no "already exists" error)
 DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
 CREATE TRIGGER on_auth_user_created
   AFTER INSERT ON auth.users
   FOR EACH ROW
   EXECUTE FUNCTION public.handle_new_user();
-
 
 -- Trigger to sync email changes from auth.users to users table
 CREATE OR REPLACE FUNCTION sync_user_email()
@@ -83,3 +81,13 @@ CREATE TRIGGER on_auth_user_email_updated
   EXECUTE FUNCTION sync_user_email();
 
 -- How to update email with the trigger: supabase_admin.auth.admin.update_user_by_id(user_id, {"email": new_email})
+
+CREATE OR REPLACE FUNCTION public.insert_secret(secret TEXT)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  RETURN vault.create_secret(secret);
+END;
+$$;

--- a/supabase/migrations/20251226061640_functions.sql
+++ b/supabase/migrations/20251226061640_functions.sql
@@ -91,3 +91,13 @@ BEGIN
   RETURN vault.create_secret(secret);
 END;
 $$;
+
+CREATE OR REPLACE FUNCTION public.get_secret(secret_id UUID)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  RETURN (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE id = secret_id);
+END;
+$$;

--- a/supabase/snippets/Untitled query 966.sql
+++ b/supabase/snippets/Untitled query 966.sql
@@ -1,1 +1,4 @@
-SELECT * FROM vault.secrets LIMIT 1;
+SELECT proname, pg_get_function_arguments(oid)
+FROM pg_proc
+WHERE proname = 'update_secret'
+AND pronamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'vault');

--- a/supabase/snippets/Untitled query 966.sql
+++ b/supabase/snippets/Untitled query 966.sql
@@ -1,0 +1,1 @@
+SELECT * FROM vault.secrets LIMIT 1;


### PR DESCRIPTION
Added an API key to be able to use the bot.

This ensures that those accessing the API to get a response can only be from the user that created the bot in the first place. An example of this is to be able to use the bot through their website or a user testing it, but then a malicious person couldn't use the same request format to get a response without said API key.

It creates an API key on bot creation.
There is an endpoint for updating the bot's API key.
The API key is shown once on creation or update for security reasons.
The API key is hashed and stored on creation in the Supabase vault with a vault uuid stored in the bots table.

Everything changed and added has been unit tested.